### PR TITLE
Add fix for mod paths to be relative to arma directory

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -7,7 +7,7 @@ import workshop
 
 
 def mod_param(name, mods):
-    return ' -{}="{}" '.format(name, ";".join(mods))
+    return ' -{}="{}" '.format(name, ";".join(mods)).replace('/arma3/', '')
 
 
 def env_defined(key):


### PR DESCRIPTION
Took me a day and a half to figure out but the mod paths must be relative to the arma3 directory. When adding mods the server would show the mod name but not the hash of the mod because it couldn't read it.